### PR TITLE
remove 'rapidjson/filestream.h' from project file this cause 'The pro…

### DIFF
--- a/cocos/2d/libcocos2d.vcxproj
+++ b/cocos/2d/libcocos2d.vcxproj
@@ -571,7 +571,6 @@ xcopy /Y /Q "$(ProjectDir)..\..\external\chipmunk\prebuilt\win32\*.*" "$(OutDir)
     <ClInclude Include="..\..\external\flatbuffers\idl.h" />
     <ClInclude Include="..\..\external\flatbuffers\util.h" />
     <ClInclude Include="..\..\external\json\document.h" />
-    <ClInclude Include="..\..\external\json\filestream.h" />
     <ClInclude Include="..\..\external\json\internal\pow10.h" />
     <ClInclude Include="..\..\external\json\internal\stack.h" />
     <ClInclude Include="..\..\external\json\internal\strfunc.h" />

--- a/cocos/2d/libcocos2d.vcxproj.filters
+++ b/cocos/2d/libcocos2d.vcxproj.filters
@@ -2147,9 +2147,6 @@
     <ClInclude Include="..\..\external\json\document.h">
       <Filter>cocostudio\json\rapidjson</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\external\json\filestream.h">
-      <Filter>cocostudio\json\rapidjson</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\external\json\prettywriter.h">
       <Filter>cocostudio\json\rapidjson</Filter>
     </ClInclude>


### PR DESCRIPTION
rapidjson中没有filestream.h这个文件。在vs中调试的话，会出现 "此项目已经过期" 的错误。
