### PR TITLE
加密lua脚本增加对php7支持

### DIFF
--- a/quick/bin/lib/quick/ScriptsCompiler.php
+++ b/quick/bin/lib/quick/ScriptsCompiler.php
@@ -320,7 +320,8 @@ class ScriptsCompiler
         // create ZIP archive
         $zipfile = $this->config['output'];
         $zip = new ZipArchive();
-        if (!$zip->open($zipfile, ZIPARCHIVE::OVERWRITE | ZIPARCHIVE::CM_STORE))
+				$flag = current(explode('.', PHP_VERSION)) == '7' ? ZIPARCHIVE::CREATE | ZIPARCHIVE::OVERWRITE : ZIPARCHIVE::OVERWRITE | ZIPARCHIVE::CM_STORE;
+        if (!$zip->open($zipfile, $flag))
         {
             return false;
         }


### PR DESCRIPTION
加密lua脚本时，如果当前php版本是7的话，会发生错误，现已修复
