### PR TITLE
Rewind stack after register pb.

### DIFF
--- a/quick/lib/quick-src/lua_extensions/protobuf/pb.c
+++ b/quick/lib/quick-src/lua_extensions/protobuf/pb.c
@@ -497,5 +497,6 @@ int luaopen_pb (lua_State *L)
     luaL_register(L, NULL, _c_iostring_m);
 
     luaL_register(L, "pb", _pb);
+    lua_pop(L, 2);
     return 1;
 } 


### PR DESCRIPTION
Otherwise the stack top is `package.preload` after
`quick_module_register` in `AppDelegate.cpp`. This is also why
`lua_getglobal(L, "_G")` is required in `quick_module_register`.