### PR TITLE
Fix ttf outline effect

### DIFF
--- a/cocos/2d/CCFontFreeType.cpp
+++ b/cocos/2d/CCFontFreeType.cpp
@@ -269,10 +269,11 @@ unsigned char* FontFreeType::getGlyphBitmap(unsigned short theChar, long &outWid
                 break;
         }
 
-        outRect.origin.x    = _fontRef->glyph->metrics.horiBearingX >> 6;
-        outRect.origin.y    = - (_fontRef->glyph->metrics.horiBearingY >> 6);
-        outRect.size.width  =   (_fontRef->glyph->metrics.width  >> 6);
-        outRect.size.height =   (_fontRef->glyph->metrics.height >> 6);
+        auto& metrics = _fontRef->glyph->metrics;
+        outRect.origin.x = metrics.horiBearingX >> 6;
+        outRect.origin.y = -(metrics.horiBearingY >> 6);
+        outRect.size.width = (metrics.width >> 6);
+        outRect.size.height = (metrics.height >> 6);
 
         xAdvance = (static_cast<int>(_fontRef->glyph->metrics.horiAdvance >> 6));
 
@@ -294,35 +295,46 @@ unsigned char* FontFreeType::getGlyphBitmap(unsigned short theChar, long &outWid
                 break;
             }
 
-            auto outlineWidth = (bbox.xMax - bbox.xMin)>>6;
-            auto outlineHeight = (bbox.yMax - bbox.yMin)>>6;
+            long glyphMinX = outRect.origin.x;
+            long glyphMaxX = outRect.origin.x + outWidth;
+            long glyphMinY = -outHeight - outRect.origin.y;
+            long glyphMaxY = -outRect.origin.y;
 
-            auto blendWidth = outlineWidth > outWidth ? outlineWidth : outWidth;
-            auto blendHeight = outlineHeight > outHeight ? outlineHeight : outHeight;
+            auto outlineMinX = bbox.xMin >> 6;
+            auto outlineMaxX = bbox.xMax >> 6;
+            auto outlineMinY = bbox.yMin >> 6;
+            auto outlineMaxY = bbox.yMax >> 6;
+            auto outlineWidth = outlineMaxX - outlineMinX;
+            auto outlineHeight = outlineMaxY - outlineMinY;
 
-            long index,index2;
+            auto blendImageMinX = MIN(outlineMinX, glyphMinX);
+            auto blendImageMaxY = MAX(outlineMaxY, glyphMaxY);
+            auto blendWidth = MAX(outlineMaxX, glyphMaxX) - blendImageMinX;
+            auto blendHeight = blendImageMaxY - MIN(outlineMinY, glyphMinY);
+
+            long index, index2;
             auto blendImage = new unsigned char[blendWidth * blendHeight * 2];
             memset(blendImage, 0, blendWidth * blendHeight * 2);
 
-            auto px = (blendWidth - outlineWidth) / 2;
-            auto py = (blendHeight - outlineHeight) / 2;
+            auto px = outlineMinX - blendImageMinX;
+            auto py = blendImageMaxY - outlineMaxY;
             for (int x = 0; x < outlineWidth; ++x)
             {
                 for (int y = 0; y < outlineHeight; ++y)
                 {
-                    index = px + x + ( (py + y) * blendWidth );
+                    index = px + x + ((py + y) * blendWidth);
                     index2 = x + (y * outlineWidth);
                     blendImage[2 * index] = outlineBitmap[index2];
                 }
             }
 
-            px = (blendWidth - outWidth) / 2;
-            py = (blendHeight - outHeight) / 2;
+            px = glyphMinX - blendImageMinX;
+            py = blendImageMaxY - glyphMaxY;
             for (int x = 0; x < outWidth; ++x)
             {
                 for (int y = 0; y < outHeight; ++y)
                 {
-                    index = px + x + ( (y + py) * blendWidth );
+                    index = px + x + ((y + py) * blendWidth);
                     index2 = x + (y * outWidth);
                     blendImage[2 * index + 1] = copyBitmap[index2];
                 }

--- a/cocos/2d/CCFontFreeType.cpp
+++ b/cocos/2d/CCFontFreeType.cpp
@@ -312,6 +312,9 @@ unsigned char* FontFreeType::getGlyphBitmap(unsigned short theChar, long &outWid
             auto blendWidth = MAX(outlineMaxX, glyphMaxX) - blendImageMinX;
             auto blendHeight = blendImageMaxY - MIN(outlineMinY, glyphMinY);
 
+            outRect.origin.x = blendImageMinX;
+            outRect.origin.y = -blendImageMaxY;
+
             long index, index2;
             auto blendImage = new unsigned char[blendWidth * blendHeight * 2];
             memset(blendImage, 0, blendWidth * blendHeight * 2);

--- a/cocos/2d/CCFontFreeType.cpp
+++ b/cocos/2d/CCFontFreeType.cpp
@@ -345,7 +345,6 @@ unsigned char* FontFreeType::getGlyphBitmap(unsigned short theChar, long &outWid
                 }
             }
 
-            xAdvance += 2 * _outlineSize;
             outRect.size.width  =  blendWidth;
             outRect.size.height =  blendHeight;
             outWidth  = blendWidth;

--- a/cocos/2d/CCFontFreeType.h
+++ b/cocos/2d/CCFontFreeType.h
@@ -55,7 +55,7 @@ public:
     
     unsigned char       * getGlyphBitmap(unsigned short theChar, long &outWidth, long &outHeight, Rect &outRect,int &xAdvance);
     
-    virtual int           getFontMaxHeight() const override;  
+    virtual int           getFontMaxHeight() const override { return _lineHeight; }
     virtual int           getFontAscender() const;
 
 protected:
@@ -79,6 +79,8 @@ private:
     std::string       _fontName;
     bool              _distanceFieldEnabled;
     float             _outlineSize;
+    int _lineHeight;
+    FontAtlas* _fontAtlas;
 };
 
 NS_CC_END


### PR DESCRIPTION
之前 outline 效果很差，字的 baseline 对不齐，字本身和 outline 也对得不齐。@WenhaiLin 在官方分支上做了很多修复，现在效果已经很完美了。

这是 patch 之前 outline 的效果

![2017-04-07_15-38-34](https://cloud.githubusercontent.com/assets/35768/24790101/56cdab06-1ba8-11e7-8915-f73dfe7a2203.png)

吹里的『人』和最后的『子』很明显对得不齐，而且『子』的 baseline 比其它字要低。

Patch 之后

![2017-04-07_15-38-10](https://cloud.githubusercontent.com/assets/35768/24790114/6374dd2a-1ba8-11e7-9594-d06b967e9d97.png)

---

最后一个提交 d95aad1 只去掉了打开 outline 后增加的字间距，但是没有合并来源提交中 CCLabel 中的相关修改，在 outline 宽度比较大的时候会出现 outline 覆盖字本体的情况。因为 CCLabel 和官方分支差异比较大了所以没有应用原来的提交，大致的思想是先画 outline，然后在 outline 上再绘制本体。

并且这个提交是会影响已有项目的，已用代码如果打开了 outline，会导致更新框架后间距变小。
