### PR TITLE
xxtea:加密/解密空字符串时造成闪退

### DIFF
--- a/external/xxtea/xxtea.cpp
+++ b/external/xxtea/xxtea.cpp
@@ -22,11 +22,11 @@
 
 static void xxtea_long_encrypt(xxtea_long *v, xxtea_long len, xxtea_long *k)
 {
-    xxtea_long n = len - 1;
-    xxtea_long z = v[n], y = v[0], p, q = 6 + 52 / (n + 1), sum = 0, e;
-    if (n < 1) {
+    if (len <= 1) {
         return;
     }
+    xxtea_long n = len - 1;
+    xxtea_long z = v[n], y = v[0], p, q = 6 + 52 / (n + 1), sum = 0, e;
     while (0 < q--) {
         sum += XXTEA_DELTA;
         e = sum >> 2 & 3;
@@ -41,11 +41,11 @@ static void xxtea_long_encrypt(xxtea_long *v, xxtea_long len, xxtea_long *k)
 
 static void xxtea_long_decrypt(xxtea_long *v, xxtea_long len, xxtea_long *k)
 {
-    xxtea_long n = len - 1;
-    xxtea_long z = v[n], y = v[0], p, q = 6 + 52 / (n + 1), sum = q * XXTEA_DELTA, e;
-    if (n < 1) {
+    if (len <= 1) {
         return;
     }
+    xxtea_long n = len - 1;
+    xxtea_long z = v[n], y = v[0], p, q = 6 + 52 / (n + 1), sum = q * XXTEA_DELTA, e;
     while (sum != 0) {
         e = sum >> 2 & 3;
         for (p = n; p > 0; p--) {


### PR DESCRIPTION
当字符串长度为0时，把len-1赋值给一个uint32_t变量，会在后面的循环中造成越界。
`xxtea_long n = len - 1;`
